### PR TITLE
Node addition

### DIFF
--- a/tree/src/merkle.rs
+++ b/tree/src/merkle.rs
@@ -527,4 +527,58 @@ mod tests {
 
         assert_eq!(proof, desired_proof);
     }
+
+    #[test]
+    /// Test if adding a new element creates a new level on the tree
+    /// 
+    /// If we start a Merkle Tree with an input array of 4 elements,
+    /// this will create a tree with 3 levels. If we add an element
+    /// the base level grows, creating a new level on the tree.
+    fn add_element_creates_new_level() {
+        let data = vec!["Crypto", "Merkle", "Rust", "Tree"];
+        let mut desired_merkle_levels = 3;
+        let mut merkle = MerkleTree::new(data);
+
+        assert_eq!(merkle.arr.len(), desired_merkle_levels);
+
+        merkle.add_element("Test");
+        desired_merkle_levels = 4;
+
+        assert_eq!(merkle.arr.len(), desired_merkle_levels);
+    }
+
+    #[test]
+    /// Test if adding a new element, doubles the quantity of
+    /// base elements.
+    /// 
+    /// If we start a Merkle Tree with an input array of 4 elements,
+    /// by adding an element we no longer have a base level with
+    /// a quantity that is a power of 2. So to have that again
+    /// we need to have repeated values. In this case, we should
+    /// end up having a base level with 8 elements.
+    fn add_element_doubles_base_elements() {
+        let data = vec!["Crypto", "Merkle", "Rust", "Tree"];
+        let mut desired_base_level_quantity = data.len();
+        let mut merkle = MerkleTree::new(data);
+
+        assert_eq!(merkle.arr[LEVEL_0].len(), desired_base_level_quantity);
+
+        merkle.add_element("Test");
+        desired_base_level_quantity *= 2;
+
+        assert_eq!(merkle.arr[LEVEL_0].len(), desired_base_level_quantity);
+    }
+
+    #[test]
+    fn add_element_creates_correct_hashes() {
+        let data = vec!["Crypto", "Merkle"];
+        let new_elem = "Rust";
+        let mut merkle = MerkleTree::new(data);
+
+        merkle.add_element(new_elem);
+        let new_elem_hash = hash_element(new_elem);
+
+        assert_eq!(merkle.arr[LEVEL_0][2], new_elem_hash);
+        assert_eq!(merkle.arr[LEVEL_0][3], new_elem_hash)
+    }
 }

--- a/tree/src/merkle.rs
+++ b/tree/src/merkle.rs
@@ -570,15 +570,19 @@ mod tests {
     }
 
     #[test]
+    /// Test if the base level elements are correct when adding a new element
+    /// in a tree that already has a base level of 2^n different elements
     fn add_element_creates_correct_hashes() {
         let data = vec!["Crypto", "Merkle"];
         let new_elem = "Rust";
         let mut merkle = MerkleTree::new(data);
+        let old_root = merkle.arr[1][0];
 
         merkle.add_element(new_elem);
         let new_elem_hash = hash_element(new_elem);
 
         assert_eq!(merkle.arr[LEVEL_0][2], new_elem_hash);
-        assert_eq!(merkle.arr[LEVEL_0][3], new_elem_hash)
+        assert_eq!(merkle.arr[LEVEL_0][3], new_elem_hash);
+        assert!(!merkle.is_root(old_root));
     }
 }


### PR DESCRIPTION
Now it is possible to add an element on the tree. Adding a new element has 2 cases.

The first case is when the tree was created from an array of 2^n different elements. This means that there are no repeated elements on the base level. So when we add a a new element, we also need to add repeated values to the base level so we keep having a len of 2^n elements (in this case, they are not all different). By adding all this elements to the base level, a whole new subtree can be created that will be the half of the new original tree. All we do is create this subtree and concatenate its root with the one of the original tree, creating the new root.

The second case is when the tree was created from an array that had a len that was not a power of 2. Here we will have a base level with repeated values, that were used to reach a 2^n len. What we do in this case is replace the first repeated value with the new hash and re-calculate the necessary nodes until we reach the root (which will be re-calculated also).